### PR TITLE
Upgrade dependencies

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -43,6 +43,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
     }
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -53,10 +53,8 @@ dependencies {
 
     implementation(libs.androidx.activityCompose)
     implementation(libs.androidx.compose.animation.graphics)
-    implementation(libs.androidx.compose.runtime.livedata)
     implementation(libs.androidx.navigation.compose)
 
-    implementation(libs.androidx.lifecycle.livedata)
     implementation(libs.androidx.lifecycle.runtime)
     implementation(libs.androidx.lifecycle.viewmodel)
 

--- a/common-compose-ui/build.gradle.kts
+++ b/common-compose-ui/build.gradle.kts
@@ -30,6 +30,8 @@ kotlin {
                 api(compose.ui)
                 api(compose.uiTooling)
                 implementation(projects.common)
+
+                api(libs.kotlin.coroutinesSwing)
             }
         }
         val commonTest by getting

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,12 +5,11 @@ androidCore = "1.7.0"
 androidCompileSdk = "32"
 androidMinSdk = "24"
 androidWearMinSdk = "25"
-androidTargetSdk = "31"
-androidGradlePlugin = "7.1.2"
+androidTargetSdk = "32"
+androidGradlePlugin = "7.2.0-beta04"
 appcompat = "1.4.1"
-compose = "1.1.0"
-composeAnimation = "1.1.1"
-composeMultiplatform = "1.1.0"
+compose = "1.2.0-alpha06"
+composeMultiplatform = "1.2.0-alpha01-dev651"
 dataStore = "1.0.0"
 espressoCore = "3.4.0"
 exposed = "0.32.1"
@@ -19,14 +18,14 @@ firebaseCrashlyticsGradle = "2.5.2"
 googleServices = "4.3.10"
 junit = "4.12"
 androidJunit = "1.1.3"
-koin = "3.1.4"
+koin = "3.1.5"
 kotlin = "1.6.10"
-kotlinCoroutinesTest = "1.6.0"
-ktlint = "0.43.2"
+kotlinCoroutines = "1.6.0"
+ktlint = "0.45.1"
 ktor = "1.6.7"
 lifecycle = "2.4.1"
-material = "1.4.0"
-mockk = "1.12.1"
+material = "1.5.0"
+mockk = "1.12.3"
 navigation = "2.4.0-beta01"
 ossLicensesPlugin = "0.10.4"
 playServicesOssLicenses = "17.0.0"
@@ -35,7 +34,7 @@ robolectric = "4.3.1"
 sqlDelight = "1.5.3"
 testCoreKtx = "1.4.0"
 timber = "4.7.1"
-wear = "1.2.0"
+wear = "1.3.0-alpha02"
 wearCompose = "1.0.0-alpha18"
 wearInput = "1.2.0-alpha02"
 
@@ -47,7 +46,7 @@ android-gradlePluginz = { module = "com.android.tools.build:gradle", version.ref
 androidx-activityCompose = { module = "androidx.activity:activity-compose", version.ref = "activity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 androidx-coreKtx = { module = "androidx.core:core-ktx", version.ref = "androidCore" }
-androidx-compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "composeAnimation" }
+androidx-compose-animation-graphics = { module = "androidx.compose.animation:animation-graphics", version.ref = "compose" }
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 androidx-compose-material-iconsExtended = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
 androidx-compose-runtime-livedata = { module = "androidx.compose.runtime:runtime-livedata", version.ref = "compose" }
@@ -81,7 +80,8 @@ koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-kotlin-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutinesTest" }
+kotlin-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinCoroutines" }
+kotlin-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinCoroutines" }
 kotlin-gradlePluginz = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 

--- a/wearos/build.gradle.kts
+++ b/wearos/build.gradle.kts
@@ -44,6 +44,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "1.8"
+        freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
     }
 }
 


### PR DESCRIPTION
- Android Target SDK to 32
- AGP to 7.2.0-beta04
- Compose to 1.2.0-alpha06
- Compose Multiplatform to 1.2.0-alpha01-dev651
- Koin to 3.1.5
- Kotlin Coroutines to 1.6.0
- ktlint to 0.45.1
- Material to 1.5.0
- MockK to 1.12.3
- Wear to 1.3.0-alpha02